### PR TITLE
Add support for Chrome major version > 32

### DIFF
--- a/breakpoints.less
+++ b/breakpoints.less
@@ -1,14 +1,14 @@
 html:after {
 	// used to test if browser can read getComputedStyle on pseudo elements
 	content: "js-breakpoints-getComputedStyleTest";
-	display: none;
+	visibility: hidden;
 }
 
 .defineBreakpoint(@name) {
 	// store active breakpoint name in ::pseudo content
 	&:after {
 		content: @name;
-		display: none;
+		visibility: hidden;
 	}
 
 	// add fallback style using breakpoint name

--- a/breakpoints.scss
+++ b/breakpoints.scss
@@ -1,14 +1,14 @@
 html:after {
 	// used to test if browser can read getComputedStyle on pseudo elements
 	content: "js-breakpoints-getComputedStyleTest";
-	display: none;
+	visibility: hidden;
 }
 
 @mixin defineBreakpoint($name) {
 	// store active breakpoint name in ::pseudo content
 	&:after {
 		content: $name;
-		display: none;
+		visibility: hidden;
 	}
 	
 	// add fallback style using breakpoint name


### PR DESCRIPTION
Elements with display set to none are no longer accessible through
getComputedStyle (not being in the DOM). Using CSS visibility will keep
them in the DOM and allow for the breakpoint to work. Note that since
they are in the DOM they will occupy screen space and I assume also
affect the actual height of the container.
