### PR TITLE
CSS Spacing Issue

### DIFF
--- a/breakpoints.less
+++ b/breakpoints.less
@@ -4,7 +4,7 @@ html:after {
 	visibility: hidden;
 	position: absolute;
  	clip: rect(0 0 0 0);
- 	overflow:hidden;
+ 	overflow: hidden;
  	width: 0;
  	height: 0;
 }
@@ -16,7 +16,7 @@ html:after {
 		visibility: hidden;
 		position: absolute;
  		clip: rect(0 0 0 0);
- 		overflow:hidden;
+ 		overflow: hidden;
 	 	width: 0;
 	 	height: 0;
 	}

--- a/breakpoints.less
+++ b/breakpoints.less
@@ -4,6 +4,9 @@ html:after {
 	visibility: hidden;
 	position: absolute;
  	clip: rect(0 0 0 0);
+ 	overflow:hidden;
+ 	width: 0;
+ 	height: 0;
 }
 
 .defineBreakpoint(@name) {
@@ -13,6 +16,9 @@ html:after {
 		visibility: hidden;
 		position: absolute;
  		clip: rect(0 0 0 0);
+ 		overflow:hidden;
+	 	width: 0;
+	 	height: 0;
 	}
 
 	// add fallback style using breakpoint name

--- a/breakpoints.scss
+++ b/breakpoints.scss
@@ -3,7 +3,10 @@ html:after {
 	content: "js-breakpoints-getComputedStyleTest";
 	visibility: hidden;
 	position: absolute;
- 	clip: rect(0 0 0 0);
+	clip: rect(0 0 0 0);
+ 	overflow:hidden; 		
+ 	width: 0;
+ 	height: 0;
 }
 
 @mixin defineBreakpoint($name) {
@@ -11,8 +14,11 @@ html:after {
 	&:after {
 		content: $name;
 		visibility: hidden;
-		position: absolute;
+		position: absolute;		
  		clip: rect(0 0 0 0);
+ 		overflow:hidden;
+	 	width: 0;
+	 	height: 0;
 	}
 	
 	// add fallback style using breakpoint name

--- a/breakpoints.scss
+++ b/breakpoints.scss
@@ -4,7 +4,7 @@ html:after {
 	visibility: hidden;
 	position: absolute;
 	clip: rect(0 0 0 0);
- 	overflow:hidden; 		
+ 	overflow: hidden; 		
  	width: 0;
  	height: 0;
 }
@@ -16,7 +16,7 @@ html:after {
 		visibility: hidden;
 		position: absolute;		
  		clip: rect(0 0 0 0);
- 		overflow:hidden;
+ 		overflow: hidden;
 	 	width: 0;
 	 	height: 0;
 	}


### PR DESCRIPTION
clip: rect() doesn't change the height of the :before and :after pseudo elements. In some cases this causes a spacing issue at the end of a website. This issue can be fixed by setting overflow hidden and setting width and height to 0.
